### PR TITLE
Fix auth issues

### DIFF
--- a/api/auth/auth.py
+++ b/api/auth/auth.py
@@ -13,7 +13,8 @@ bearer_transport = BearerTransport(tokenUrl="auth/jwt/login")
 
 
 def get_jwt_strategy() -> JWTStrategy[models.UP, models.ID]:
-    return JWTStrategy(secret=SECRET, lifetime_seconds=3600)
+    # Extend token lifetime to one week (7 days)
+    return JWTStrategy(secret=SECRET, lifetime_seconds=604800)
 
 
 auth_backend = AuthenticationBackend(

--- a/components/RegisterForm.tsx
+++ b/components/RegisterForm.tsx
@@ -36,11 +36,22 @@ export default function RegisterForm({ onLogin }: { onLogin: (token: string) => 
 
     try {
       console.log("Registering with form:", form);
-      // CORRECTED URL for register
+      // Convert camelCase fields to snake_case for the API
+      const payload = {
+        email: form.email,
+        password: form.password,
+        display_name: form.displayName,
+        weight: form.weight,
+        height: form.height,
+        gender: form.gender,
+        dob: form.dob,
+        real_dob: form.realDob,
+      };
+
       const res = await fetch("/api/auth/register", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(form),
+        body: JSON.stringify(payload),
       });
 
       if (!res.ok) {


### PR DESCRIPTION
## Summary
- handle snake_case payload for sign-up
- extend JWT lifetime to 1 week

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684086c87fcc83319f7a4da3149ef30f