### PR TITLE
Improve responsive account and group widgets

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { BAPTenderProvider } from "@/context/BAPTenderContext";
+import { PopupProvider } from "@/context/PopupContext";
 import AuthGate from "@/components/AuthGate";
 import Header from "@/components/Header";
 import dynamic from "next/dynamic";
@@ -86,9 +87,10 @@ export default function HomePage() {
 
   if (!token) { // If token is null after loading and verification attempt
     return (
-      <div className={currentThemeName}>
-        <CustomParticlesBackground currentTheme={currentThemeName} />
-        <main className="min-h-screen flex flex-col items-center justify-center p-4 relative z-10">
+      <PopupProvider>
+        <div className={currentThemeName}>
+          <CustomParticlesBackground currentTheme={currentThemeName} />
+          <main className="min-h-screen flex flex-col items-center justify-center p-4 relative z-10">
           <h1
             className="glitch text-5xl md:text-7xl mb-2 font-vt323 cursor-pointer"
             data-text="BAPTender!"
@@ -103,19 +105,21 @@ export default function HomePage() {
             localStorage.setItem("token", newToken); // Ensure token is set on successful login via AuthGate
             setToken(newToken);
           }} />
-        </main>
-      </div>
+          </main>
+        </div>
+      </PopupProvider>
     );
   }
 
   // Token is valid, render the authenticated app
 // Token is valid, render the authenticated app
 return (
-  <BAPTenderProvider token={token}>
-    <div className={currentThemeName}>
-      <CustomParticlesBackground currentTheme={currentThemeName} />
-      <div className="min-h-screen flex flex-col relative z-10">
-        <Header onThemeToggle={toggleTheme} currentThemeName={currentThemeName}/>
+  <PopupProvider>
+    <BAPTenderProvider token={token}>
+      <div className={currentThemeName}>
+        <CustomParticlesBackground currentTheme={currentThemeName} />
+        <div className="min-h-screen flex flex-col relative z-10">
+          <Header onThemeToggle={toggleTheme} currentThemeName={currentThemeName}/>
 
         {/* 👇 REFACTORED MAIN SECTION 👇 */}
         {/* We make the main container a flex column and apply a single gap to space out its direct children perfectly. */}
@@ -145,9 +149,10 @@ return (
             className="text-center px-4 py-0 font-vt323 text-xs text-accent-color border-t border-t-[var(--card-border-color)]">
           BAPTender - Always verify BAC with a calibrated breathalyzer.
         </footer>
+        </div>
       </div>
-    </div>
-  </BAPTenderProvider>
+    </BAPTenderProvider>
+  </PopupProvider>
 );
 }
 

--- a/components/Account.tsx
+++ b/components/Account.tsx
@@ -46,6 +46,8 @@ export default function AccountWidget() {
   const windowWidth = useWindowWidth();
   // Switch to compact icon view a bit earlier so the widgets fit beside the logo
   const showIconOnly = windowWidth < 640;
+  // Dynamic compact size so the button can shrink but stay square
+  const compactSize = Math.max(40, Math.min(60, windowWidth / 8));
   const { activePopup, setActivePopup } = usePopup();
 
   const [expanded, setExpanded] = useState(false);
@@ -193,8 +195,20 @@ export default function AccountWidget() {
           setActivePopup(next ? "account" : null);
           if (next) resetFormData();
         }}
-        className="themed-button text-sm p-[var(--small-spacing)] flex items-center justify-center"
-        style={{ minWidth: showIconOnly ? "40px" : "150px" }}
+        className={`themed-button text-sm flex items-center justify-center ${
+          showIconOnly ? '' : 'p-[var(--small-spacing)]'
+        }`}
+        style={
+          showIconOnly
+            ? {
+                width: compactSize,
+                height: compactSize,
+                minWidth: compactSize,
+                minHeight: compactSize,
+                padding: 'var(--tiny-spacing)',
+              }
+            : { minWidth: '150px', padding: 'var(--small-spacing)' }
+        }
         title={
           showIconOnly
             ? userFromContext.displayName

--- a/components/Account.tsx
+++ b/components/Account.tsx
@@ -213,7 +213,7 @@ export default function AccountWidget() {
 
       {expanded && (
         <div
-          className="absolute left-1/2 -translate-x-1/2 mt-[var(--small-spacing)] w-[90vw] max-w-sm sm:left-auto sm:translate-x-0 sm:right-0 sm:min-w-[320px] sm:w-auto sm:max-w-md themed-card p-[var(--base-spacing)] shadow-2xl z-50"
+          className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[90vw] max-w-sm sm:absolute sm:top-full sm:left-auto sm:right-0 sm:translate-x-0 sm:translate-y-0 sm:mt-[var(--small-spacing)] sm:min-w-[320px] sm:w-auto sm:max-w-md themed-card p-[var(--base-spacing)] shadow-2xl z-50"
         >
           <div className="flex justify-between items-center mb-[var(--base-spacing)]">
             <h2

--- a/components/Account.tsx
+++ b/components/Account.tsx
@@ -44,7 +44,8 @@ export default function AccountWidget() {
   const { state } = useBAPTender();
   const userFromContext = state.self;
   const windowWidth = useWindowWidth();
-  const showIconOnly = windowWidth < 480;
+  // Switch to compact icon view a bit earlier so the widgets fit beside the logo
+  const showIconOnly = windowWidth < 640;
   const { activePopup, setActivePopup } = usePopup();
 
   const [expanded, setExpanded] = useState(false);

--- a/components/Account.tsx
+++ b/components/Account.tsx
@@ -207,7 +207,12 @@ export default function AccountWidget() {
                 minHeight: compactSize,
                 padding: 'var(--tiny-spacing)',
               }
-            : { minWidth: '150px', padding: 'var(--small-spacing)' }
+            : {
+                minWidth: '150px',
+                height: compactSize,
+                minHeight: compactSize,
+                padding: 'var(--small-spacing)',
+              }
         }
         title={
           showIconOnly
@@ -228,7 +233,8 @@ export default function AccountWidget() {
 
       {expanded && (
         <div
-          className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[90vw] max-w-sm sm:absolute sm:top-full sm:left-auto sm:right-0 sm:translate-x-0 sm:translate-y-0 sm:mt-[var(--small-spacing)] sm:min-w-[320px] sm:w-auto sm:max-w-md themed-card p-[var(--base-spacing)] shadow-2xl z-50"
+          className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[90vw] max-w-sm sm:absolute sm:top-full sm:left-auto sm:right-0 sm:translate-x-0 sm:translate-y-0 sm:mt-[var(--small-spacing)] sm:min-w-[320px] sm:w-auto sm:max-w-md themed-card p-[var(--base-spacing)] shadow-2xl z-50 overflow-y-auto"
+          style={{ maxHeight: 'calc(100vh - 2rem)' }}
         >
           <div className="flex justify-between items-center mb-[var(--base-spacing)]">
             <h2

--- a/components/Groups.tsx
+++ b/components/Groups.tsx
@@ -321,7 +321,12 @@ export default function GroupsWidget() {
                 minHeight: compactSize,
                 padding: 'var(--tiny-spacing)',
               }
-            : { minWidth: '80px', padding: 'var(--small-spacing)' }
+            : {
+                minWidth: '80px',
+                height: compactSize,
+                minHeight: compactSize,
+                padding: 'var(--small-spacing)',
+              }
         }
         title={showIconOnly && currentGroup?.name ? currentGroup.name : undefined}
       >
@@ -338,7 +343,8 @@ export default function GroupsWidget() {
         // Adjusted width: min-content, max-w-sm for mobile, md:max-w-md for larger.
         // Increased max-h slightly, adjusted padding for less claustrophobia.
         <div
-          className="fixed z-50 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[90vw] max-w-sm sm:absolute sm:top-full sm:left-0 sm:translate-x-0 sm:translate-y-0 sm:mt-[var(--small-spacing)] sm:w-auto sm:min-w-[300px] sm:max-w-md md:max-w-lg max-h-[150vh] overflow-y-auto themed-card p-[var(--small-spacing)] md:p-[var(--base-spacing)] shadow-2xl"
+          className="fixed z-50 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[90vw] max-w-sm sm:absolute sm:top-full sm:left-0 sm:translate-x-0 sm:translate-y-0 sm:mt-[var(--small-spacing)] sm:w-auto sm:min-w-[300px] sm:max-w-md md:max-w-lg themed-card p-[var(--small-spacing)] md:p-[var(--base-spacing)] shadow-2xl overflow-y-auto"
+          style={{ maxHeight: 'calc(100vh - 2rem)' }}
         >
           <div className="flex justify-between items-center mb-[var(--base-spacing)]">
             {" "}

--- a/components/Groups.tsx
+++ b/components/Groups.tsx
@@ -42,6 +42,7 @@ export default function GroupsWidget() {
   const windowWidth = useWindowWidth();
   // Switch to the icon view around the same breakpoint used for Account
   const showIconOnly = windowWidth < 640;
+  const compactSize = Math.max(40, Math.min(60, windowWidth / 8));
   const { activePopup, setActivePopup } = usePopup();
 
   const [expanded, setExpanded] = useState(false);
@@ -308,7 +309,20 @@ export default function GroupsWidget() {
           setExpanded(next);
           setActivePopup(next ? "groups" : null);
         }}
-        className="themed-button text-sm p-[var(--small-spacing)] min-w-[80px] md:min-w-[80px] flex items-center justify-center text-left leading-tight"
+        className={`themed-button text-sm flex items-center justify-center text-left leading-tight ${
+          showIconOnly ? '' : 'p-[var(--small-spacing)]'
+        }`}
+        style={
+          showIconOnly
+            ? {
+                width: compactSize,
+                height: compactSize,
+                minWidth: compactSize,
+                minHeight: compactSize,
+                padding: 'var(--tiny-spacing)',
+              }
+            : { minWidth: '80px', padding: 'var(--small-spacing)' }
+        }
         title={showIconOnly && currentGroup?.name ? currentGroup.name : undefined}
       >
         {showIconOnly ? (

--- a/components/Groups.tsx
+++ b/components/Groups.tsx
@@ -40,7 +40,8 @@ export default function GroupsWidget() {
   const currentGroup: GroupType | null = state.group?.id ? state.group : null;
   const currentMembers: GroupMember[] = state.members || [];
   const windowWidth = useWindowWidth();
-  const showIconOnly = windowWidth < 480;
+  // Switch to the icon view around the same breakpoint used for Account
+  const showIconOnly = windowWidth < 640;
   const { activePopup, setActivePopup } = usePopup();
 
   const [expanded, setExpanded] = useState(false);
@@ -308,24 +309,12 @@ export default function GroupsWidget() {
           setActivePopup(next ? "groups" : null);
         }}
         className="themed-button text-sm p-[var(--small-spacing)] min-w-[80px] md:min-w-[80px] flex items-center justify-center text-left leading-tight"
-        title={
-          showIconOnly && currentGroup?.name
-            ? `${currentGroup.name} (${currentGroup.public ? "Public" : "Private"})`
-            : undefined
-        }
+        title={showIconOnly && currentGroup?.name ? currentGroup.name : undefined}
       >
         {showIconOnly ? (
           <UsersIcon />
         ) : currentGroup?.name ? (
-          <>
-            <span className="font-semibold block truncate">
-              {currentGroup.name}
-            </span>
-            <span className="text-xs italic opacity-80">
-              ({currentGroup.public ? "Public" : "Private"}) {currentMembers.length}
-              {" "}Mbr(s)
-            </span>
-          </>
+          <span className="font-semibold block truncate">{currentGroup.name}</span>
         ) : (
           <span>No Group</span>
         )}

--- a/components/Groups.tsx
+++ b/components/Groups.tsx
@@ -335,11 +335,7 @@ export default function GroupsWidget() {
         // Adjusted width: min-content, max-w-sm for mobile, md:max-w-md for larger.
         // Increased max-h slightly, adjusted padding for less claustrophobia.
         <div
-          className="absolute z-50 top-full left-1/2 -translate-x-1/2 mt-[var(--small-spacing)]
-                         w-[90vw] max-w-sm sm:left-0 sm:translate-x-0 sm:right-auto
-                         sm:min-w-[300px] sm:w-auto sm:max-w-md md:max-w-lg
-                         max-h-[150vh] overflow-y-auto
-                         themed-card p-[var(--small-spacing)] md:p-[var(--base-spacing)] shadow-2xl"
+          className="fixed z-50 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[90vw] max-w-sm sm:absolute sm:top-full sm:left-0 sm:translate-x-0 sm:translate-y-0 sm:mt-[var(--small-spacing)] sm:w-auto sm:min-w-[300px] sm:max-w-md md:max-w-lg max-h-[150vh] overflow-y-auto themed-card p-[var(--small-spacing)] md:p-[var(--base-spacing)] shadow-2xl"
         >
           <div className="flex justify-between items-center mb-[var(--base-spacing)]">
             {" "}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import GroupsWidget from "./Groups"; // Assuming this will be styled separately
 import AccountWidget from "./Account"; // Assuming this will be styled separately
+import useWindowWidth from "@/hooks/useWindowWidth";
 
 interface HeaderProps {
   onThemeToggle: () => void;
@@ -13,6 +14,15 @@ export default function Header({
   onThemeToggle,
   currentThemeName,
 }: HeaderProps) {
+  const windowWidth = useWindowWidth();
+  const logoClass =
+    windowWidth < 320
+      ? "text-xl"
+      : windowWidth < 360
+      ? "text-2xl"
+      : windowWidth < 420
+      ? "text-3xl"
+      : "text-4xl";
   return (
     <header
       className="p-[var(--base-spacing)] shadow-lg"
@@ -32,7 +42,7 @@ export default function Header({
         {/* This div is just for the logo itself. It won't grow or shrink. */}
         <div className="flex-shrink-0">
           <div
-            className="text-4xl cursor-pointer"
+            className={`${logoClass} cursor-pointer`}
             data-text="BAPTENDER"
             onClick={onThemeToggle}
             title={`Toggle Theme (Current: ${currentThemeName.replace("theme-", "")})`}

--- a/context/PopupContext.tsx
+++ b/context/PopupContext.tsx
@@ -1,0 +1,28 @@
+import React, { createContext, useContext, useState } from "react";
+
+export type PopupName = "account" | "groups" | null;
+
+interface PopupContextType {
+  activePopup: PopupName;
+  setActivePopup: (name: PopupName) => void;
+}
+
+const PopupContext = createContext<PopupContextType | undefined>(undefined);
+
+export function PopupProvider({ children }: { children: React.ReactNode }) {
+  const [activePopup, setActivePopup] = useState<PopupName>(null);
+
+  return (
+    <PopupContext.Provider value={{ activePopup, setActivePopup }}>
+      {children}
+    </PopupContext.Provider>
+  );
+}
+
+export function usePopup() {
+  const ctx = useContext(PopupContext);
+  if (!ctx) {
+    throw new Error("usePopup must be used within a PopupProvider");
+  }
+  return ctx;
+}

--- a/hooks/useWindowWidth.ts
+++ b/hooks/useWindowWidth.ts
@@ -8,6 +8,7 @@ export default function useWindowWidth() {
   useEffect(() => {
     const handleResize = () => setWidth(window.innerWidth);
     window.addEventListener("resize", handleResize);
+    handleResize();
     return () => window.removeEventListener("resize", handleResize);
   }, []);
 

--- a/hooks/useWindowWidth.ts
+++ b/hooks/useWindowWidth.ts
@@ -1,0 +1,15 @@
+import { useState, useEffect } from "react";
+
+export default function useWindowWidth() {
+  const [width, setWidth] = useState(
+    typeof window !== "undefined" ? window.innerWidth : 1024,
+  );
+
+  useEffect(() => {
+    const handleResize = () => setWidth(window.innerWidth);
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return width;
+}


### PR DESCRIPTION
## Summary
- show simple icons for Account and Groups when screen is very narrow
- center the Account and Groups popups on small screens
- add `useWindowWidth` hook for responsive helpers
- ensure only one popup (Account or Groups) can be open at a time

## Testing
- `npm run lint` *(with warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68414b4aaf2483318e3ede34342dadd4