### PR TITLE
Add Docker support with redis

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,9 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY api ./api
+COPY db ./db
+EXPOSE 8000
+CMD ["uvicorn", "api.index:app", "--host", "0.0.0.0", "--port", "8000"]
+

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,14 @@
+FROM node:18-alpine AS builder
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . ./
+RUN npm run build
+
+FROM node:18-alpine
+WORKDIR /app
+COPY --from=builder /app .
+ENV NODE_ENV=production
+EXPOSE 3000
+CMD ["npm", "start"]
+

--- a/README.md
+++ b/README.md
@@ -16,9 +16,20 @@ BAPTender is a web application that combines a Next.js frontend with a FastAPI b
    ```
 3. Start both the Next.js and FastAPI servers:
    ```bash
-   npm run dev
+  npm run dev
+  ```
+  The frontend will run on `http://localhost:3000` and the API will run on `http://127.0.0.1:8000`.
+
+## Docker Development
+
+1. Build and start the containers using docker compose:
+   ```bash
+   docker compose up --build
    ```
-   The frontend will run on `http://localhost:3000` and the API will run on `http://127.0.0.1:8000`.
+   - Frontend: <http://localhost:3000>
+   - Backend: <http://localhost:8000>
+   - PostgreSQL: <localhost:5432>
+   - Redis: <localhost:6379>
 
 ## Repository Structure
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3.8'
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
+    environment:
+      - DATABASE_URL=postgresql+asyncpg://postgres:password@db/baptender
+    depends_on:
+      - db
+      - redis
+    ports:
+      - "8000:8000"
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+    environment:
+      - API_URL=http://backend:8000
+    depends_on:
+      - backend
+    ports:
+      - "3000:3000"
+  db:
+    image: postgres:16-alpine
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=baptender
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+  redis:
+    image: redis:alpine
+    ports:
+      - "6379:6379"
+volumes:
+  db-data:
+

--- a/next.config.js
+++ b/next.config.js
@@ -1,27 +1,20 @@
 /** @type {import('next').NextConfig} */
+const API_URL = process.env.API_URL || 'http://127.0.0.1:8000';
+
 const nextConfig = {
   rewrites: async () => {
     return [
       {
-        source: "/api/:path*",
-        destination:
-          process.env.NODE_ENV === "development"
-            ? "http://127.0.0.1:8000/:path*"
-            : "/:path*",
+        source: '/api/:path*',
+        destination: `${API_URL}/:path*`,
       },
       {
-        source: "/docs",
-        destination:
-          process.env.NODE_ENV === "development"
-            ? "http://127.0.0.1:8000/docs"
-            : "/docs",
+        source: '/docs',
+        destination: `${API_URL}/docs`,
       },
       {
-        source: "/openapi.json",
-        destination:
-          process.env.NODE_ENV === "development"
-            ? "http://127.0.0.1:8000/openapi.json"
-            : "/openapi.json",
+        source: '/openapi.json',
+        destination: `${API_URL}/openapi.json`,
       },
     ];
   },


### PR DESCRIPTION
## Summary
- add Dockerfiles for frontend and backend
- set up docker-compose with Postgres and Redis
- make backend URL configurable via `API_URL`
- document Docker usage in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68430a5049248331b09e402125b86b1f