### PR TITLE
Add Docker db readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ BAPTender is a web application that combines a Next.js frontend with a FastAPI b
    ```
    The frontend will run on `http://localhost:3000` and the API will run on `http://127.0.0.1:8000`.
 
+## Docker
+
+You can also run the project using Docker. Build the images and start the
+services with:
+
+```bash
+docker compose up --build
+```
+
+The backend container waits for the database to accept connections before starting the API server. The frontend will be available on `http://localhost:3000` and the backend on `http://localhost:8000`.
+
 ## Repository Structure
 
 - `backend/` – FastAPI backend code and database scripts

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install dependencies and PostgreSQL client for health checks
+COPY requirements.txt /app/requirements.txt
+RUN apt-get update \
+    && apt-get install -y postgresql-client \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir -r requirements.txt
+
+# Copy application
+COPY . /app
+COPY wait_for_db.sh /wait_for_db.sh
+RUN chmod +x /wait_for_db.sh
+
+EXPOSE 8000
+
+CMD ["/wait_for_db.sh", "uvicorn", "api.index:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/api/index.py
+++ b/backend/api/index.py
@@ -36,8 +36,9 @@ app.include_router(group_router, prefix="/group", tags=["group"])
 app.include_router(realtime_router, prefix="/realtime", tags=["realtime"])
 
 origins = [
-    "http://localhost:3000",  # your frontend URL
-    "http://127.0.0.1:3000"
+    "http://localhost:3000",  # local dev
+    "http://127.0.0.1:3000",
+    "http://frontend:3000"  # docker compose service
 ]
 
 app.add_middleware(

--- a/backend/wait_for_db.sh
+++ b/backend/wait_for_db.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Wait for the PostgreSQL database to be ready
+set -e
+
+DB_HOST=${DB_HOST:-db}
+DB_PORT=${DB_PORT:-5432}
+DB_USER=${POSTGRES_USER:-postgres}
+
+until pg_isready -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" >/dev/null 2>&1; do
+  echo "Waiting for PostgreSQL at $DB_HOST:$DB_PORT..."
+  sleep 1
+done
+
+exec "$@"
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: baptender
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  backend:
+    build: ./backend
+    environment:
+      DATABASE_URL: postgresql+asyncpg://postgres:password@db/baptender
+      DB_HOST: db
+      DB_PORT: 5432
+      POSTGRES_USER: postgres
+    depends_on:
+      - db
+    ports:
+      - "8000:8000"
+
+  frontend:
+    build: ./frontend
+    environment:
+      BACKEND_URL: http://backend:8000
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
+
+volumes:
+  db_data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,15 @@
+# Build stage
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package.json /app/
+RUN npm install
+COPY . /app
+RUN npm run build
+
+# Production stage
+FROM node:18-alpine AS production
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app /app
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,27 +1,24 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  rewrites: async () => {
+  async rewrites() {
+    const backend =
+      process.env.BACKEND_URL ||
+      (process.env.NODE_ENV === "development"
+        ? "http://127.0.0.1:8000"
+        : "http://backend:8000");
+
     return [
       {
         source: "/api/:path*",
-        destination:
-          process.env.NODE_ENV === "development"
-            ? "http://127.0.0.1:8000/:path*"
-            : "/:path*",
+        destination: `${backend}/:path*`,
       },
       {
         source: "/docs",
-        destination:
-          process.env.NODE_ENV === "development"
-            ? "http://127.0.0.1:8000/docs"
-            : "/docs",
+        destination: `${backend}/docs`,
       },
       {
         source: "/openapi.json",
-        destination:
-          process.env.NODE_ENV === "development"
-            ? "http://127.0.0.1:8000/openapi.json"
-            : "/openapi.json",
+        destination: `${backend}/openapi.json`,
       },
     ];
   },


### PR DESCRIPTION
## Summary
- ensure backend waits for Postgres to be ready
- install postgres client in backend image
- expose DB connection details to backend service
- document new behaviour in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `npm install` and `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684331cbc3708331b46c1200ee9150dc