### PR TITLE
Remove group param from update_user

### DIFF
--- a/backend/api/auth/users.py
+++ b/backend/api/auth/users.py
@@ -3,14 +3,12 @@ import uuid
 from typing import Optional, Dict, Any
 from fastapi import Request
 from fastapi_users import BaseUserManager, UUIDIDMixin
-from sqlalchemy import select
-from sqlalchemy.orm import selectinload
+
 
 from api.auth.auth import SECRET
 from api.auth.models import User
-from api.core.db import get_async_session
 from api.realtime.actions import update_user as trigger_realtime_update
-from api.group.models import Group, UserGroup
+
 import asyncio
 
 
@@ -43,20 +41,6 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         if not relevant_fields_for_bac.isdisjoint(update_dict.keys()):
             print(f"Relevant user details updated for {user.id}, triggering Redis publish.")
 
-            async def do_update_with_session():
-                async for session in get_async_session():
-                    ug_result = await session.execute(
-                        select(UserGroup)
-                        .options(selectinload(UserGroup.group))
-                        .where(
-                            UserGroup.user_id == user.id,
-                            UserGroup.active.is_(True),
-                        )
-                    )
-                    user_group = ug_result.scalars().first()
-                    active_group = user_group.group if user_group else None
-                    await trigger_realtime_update(user, active_group)
-
-            asyncio.create_task(do_update_with_session())
+            asyncio.create_task(trigger_realtime_update(user))
         else:
             print(f"User {user.id} updated, but no BAC-relevant fields changed. Skipping update.")

--- a/backend/api/group/router.py
+++ b/backend/api/group/router.py
@@ -63,7 +63,7 @@ async def create_group(
         await session.rollback()
         raise HTTPException(status_code=409, detail="Group name already taken!")
 
-    asyncio.create_task(update_user(user, group))
+    asyncio.create_task(update_user(user))
 
     return group
 
@@ -101,7 +101,7 @@ async def switch_group(
         group = group_result.scalar_one_or_none()
 
     await session.commit()
-    asyncio.create_task(update_user(user, group))
+    asyncio.create_task(update_user(user))
     return group
 
 
@@ -192,7 +192,7 @@ async def join_group_public(
     session.add(user_group)
     await session.commit()
 
-    asyncio.create_task(update_user(user, group))
+    asyncio.create_task(update_user(user))
     return group
 
 
@@ -238,7 +238,7 @@ async def join_group(
         session.add(UserGroup(user_id=user.id, group_id=group_id, active=True))
 
     await session.commit()
-    asyncio.create_task(update_user(user, group))
+    asyncio.create_task(update_user(user))
     return group
 
 
@@ -301,11 +301,11 @@ async def leave_group(
         await session.execute(delete(Group).where(Group.id == group_id))
         await session.commit()
         # No group to update anymore, but we can notify the user they are solo
-        asyncio.create_task(update_user(user, None))
+        asyncio.create_task(update_user(user))
         return {"detail": "Deleted group."}
 
     await session.delete(user_group)
     await session.commit()
 
-    asyncio.create_task(update_user(user, group))
+    asyncio.create_task(update_user(user))
     return {"detail": "Left group."}


### PR DESCRIPTION
## Summary
- let `update_user` fetch the active group on its own
- drop `group` dependency from drink APIs
- update group-related routes to use the new `update_user` signature
- clean up user update realtime trigger
- simplify scheduler archival routine

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68435dd766bc8331b9d8b4ac50a004b8