### PR TITLE
Add button to remove last logged drink

### DIFF
--- a/frontend/components/Drinks.tsx
+++ b/frontend/components/Drinks.tsx
@@ -9,6 +9,40 @@ export default function DrinksForm() {
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  const handleRemoveLastDrink = async () => {
+    setMessage(null);
+    setError(null);
+
+    const token = localStorage.getItem("token");
+    if (!token) {
+      setError("Authentication token is missing. Please log in again.");
+      return;
+    }
+
+    try {
+      const res = await fetch("/api/drinks/last", {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!res.ok) {
+        const errorData = await res
+          .json()
+          .catch(() => ({ detail: `Request failed with status ${res.status}` }));
+        setError(`Error: ${errorData.detail}`);
+        return;
+      }
+
+      setMessage("Last drink removed!");
+      setTimeout(() => setMessage(null), 3000);
+    } catch (err) {
+      console.error("Error removing last drink:", err);
+      setError("Network hiccup while removing drink. Try again.");
+    }
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setMessage(null);
@@ -158,6 +192,13 @@ export default function DrinksForm() {
       </div>
       <button type="submit" className="themed-button w-full font-vt323 text-lg">
         Log Drink
+      </button>
+      <button
+        type="button"
+        onClick={handleRemoveLastDrink}
+        className="themed-button w-full font-vt323 text-lg"
+      >
+        Remove Last Drink
       </button>
       {message && (
         <p

--- a/frontend/components/Drinks.tsx
+++ b/frontend/components/Drinks.tsx
@@ -196,7 +196,7 @@ export default function DrinksForm() {
       <button
         type="button"
         onClick={handleRemoveLastDrink}
-        className="themed-button w-full font-vt323 text-lg"
+        className="themed-button-danger w-full font-vt323 text-sm py-1.5 mt-[var(--small-spacing)]"
       >
         Remove Last Drink
       </button>


### PR DESCRIPTION
## Summary
- add remove last drink helper to DrinksForm
- expose "Remove Last Drink" button next to "Log Drink"

## Testing
- `npm run lint -- --fix`

------
https://chatgpt.com/codex/tasks/task_e_68435e83ee908331b1c95a09172f4bf1