### PR TITLE
Add CI workflow for backend and frontend tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r backend/requirements.txt pytest pytest-asyncio httpx asgi-lifespan
+          pip install -r backend/requirements.txt pytest pytest-asyncio httpx asgi-lifespan aiosqlite
       - name: Run backend tests
         run: |
           cd backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt pytest pytest-asyncio httpx asgi-lifespan
+      - name: Run backend tests
+        run: |
+          cd backend
+          pytest
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install dependencies
+        run: |
+          cd frontend
+          npm ci
+      - name: Run frontend tests
+        run: |
+          cd frontend
+          npm test -- --runInBand
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running backend pytest suite
- run frontend Jest tests with Node

## Testing
- `pytest -q` *(backend tests)*
- `npx jest --version` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f10758a4833197f11ec8a7e6d1d2