### PR TITLE
Add CI dep and more BAC calculation tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt pytest pytest-asyncio httpx asgi-lifespan aiosqlite
+      - name: Run backend tests
+        run: |
+          cd backend
+          pytest
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install dependencies
+        run: |
+          cd frontend
+          npm ci
+      - name: Run frontend tests
+        run: |
+          cd frontend
+          npm test -- --runInBand
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 fastapi
 uvicorn[standard]==0.30.6
-pydantic
+pydantic>=2
 sqlalchemy
 fastapi-users[sqlalchemy]
 asyncpg

--- a/backend/tests/test_calculations.py
+++ b/backend/tests/test_calculations.py
@@ -88,3 +88,17 @@ def test_drinks_to_bac_multiple_rates_and_invalid_rate():
     assert results["high"][-1]["bac"] == 0.0
     with pytest.raises(AssertionError):
         drinks_to_bac(drinks, user, metabolism_rates={"bad": 0.0})
+
+
+
+def test_get_total_body_water_and_widmark_factor():
+    from api.realtime.calculations import get_total_body_water, get_widmark_factor
+    tbw = get_total_body_water("male", age=30.0, height=180.0, weight=70.0)
+    expected_tbw = 2.447 - 0.09516 * 30.0 + 0.1074 * 180.0 + 0.3362 * 70.0
+    assert pytest.approx(expected_tbw, rel=1e-6) == tbw
+
+    assert get_widmark_factor("male") == 0.68
+    assert get_widmark_factor("female") == 0.55
+    with pytest.raises(AssertionError):
+        get_widmark_factor("other")
+

--- a/backend/tests/test_groups_extra.py
+++ b/backend/tests/test_groups_extra.py
@@ -1,0 +1,107 @@
+import sys
+import pathlib
+import uuid
+import pytest
+from .test_api import _register, _login, client as client
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+@pytest.mark.anyio
+async def test_group_endpoints(client):
+    owner = {
+        "email": "owner2@example.com",
+        "password": "secret",
+        "display_name": "owner2",
+        "weight": 75,
+        "gender": "male",
+        "height": 170,
+        "dob": "1990-01-01",
+        "real_dob": True,
+    }
+    owner_pub = {
+        "email": "ownerpub@example.com",
+        "password": "secret",
+        "display_name": "ownerpub",
+        "weight": 72,
+        "gender": "male",
+        "height": 180,
+        "dob": "1985-05-05",
+        "real_dob": True,
+    }
+    member = {
+        "email": "member2@example.com",
+        "password": "secret",
+        "display_name": "member2",
+        "weight": 65,
+        "gender": "female",
+        "height": 165,
+        "dob": "1992-02-02",
+        "real_dob": True,
+    }
+
+    assert (await _register(client, owner)).status_code == 201
+    assert (await _register(client, owner_pub)).status_code == 201
+    assert (await _register(client, member)).status_code == 201
+
+    owner_token = (await _login(client, owner["email"], owner["password"])).json()["access_token"]
+    pub_owner_token = (await _login(client, owner_pub["email"], owner_pub["password"])).json()["access_token"]
+    member_token = (await _login(client, member["email"], member["password"])).json()["access_token"]
+
+    h_owner = {"Authorization": f"Bearer {owner_token}"}
+    h_pub_owner = {"Authorization": f"Bearer {pub_owner_token}"}
+    h_member = {"Authorization": f"Bearer {member_token}"}
+
+    # owner creates a private group
+    r = await client.post("/group/create", json={"name": f"priv-{uuid.uuid4()}", "public": False}, headers=h_owner)
+    assert r.status_code == 200
+    priv_id = r.json()["id"]
+
+    # another owner creates a public group
+    r = await client.post("/group/create", json={"name": f"pub-{uuid.uuid4()}", "public": True}, headers=h_pub_owner)
+    assert r.status_code == 200
+    pub_id = r.json()["id"]
+
+    # member joins public group directly
+    r = await client.post(f"/group/join/{pub_id}", headers=h_member)
+    assert r.status_code == 200
+    # leave public group to allow joining another
+    await client.post(f"/group/leave/{pub_id}", headers=h_member)
+
+    # attempt to join private group without invite should fail
+    r = await client.post(f"/group/join/{priv_id}", headers=h_member)
+    assert r.status_code == 400
+
+    # generate invite link for private group and join via token
+    invite = await client.get(f"/group/invite-link/{priv_id}", headers=h_owner)
+    token = invite.json()["invite_token"]
+    r = await client.get(f"/group/invite/{token}", headers=h_member)
+    assert r.status_code == 200
+
+    # member should now be active in private group
+    r = await client.get("/group/current", headers=h_member)
+    assert r.status_code == 200
+    assert r.json()["id"] == priv_id
+
+
+    # go solo
+    r = await client.post("/group/switch", headers=h_member)
+    assert r.status_code == 200
+    assert r.json() is None
+
+    # verify no current group
+    r = await client.get("/group/current", headers=h_member)
+    assert r.json() is None
+
+    # list my groups should include the private group
+    r = await client.get("/group/my", headers=h_member)
+    ids = {g["id"] for g in r.json()}
+    assert priv_id in ids
+
+    # list public groups should show the public one
+    r = await client.get("/group/public")
+    assert any(g["id"] == pub_id for g in r.json())

--- a/frontend/components/__tests__/AuthGate.test.tsx
+++ b/frontend/components/__tests__/AuthGate.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AuthGate from '../AuthGate';
+
+const noop = () => {};
+
+describe('AuthGate', () => {
+  it('toggles between login and register modes', async () => {
+    const user = userEvent.setup();
+    render(<AuthGate onLogin={noop} />);
+
+    expect(screen.getByRole('heading', { name: /Access Terminal/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /Register here/i }));
+    expect(screen.getByRole('heading', { name: /Enlist in BAPTender/i })).toBeInTheDocument();
+
+    await user.click(screen.getAllByRole('button', { name: /^Log in$/i })[0]);
+    expect(screen.getByRole('heading', { name: /Access Terminal/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/components/__tests__/Header.test.tsx
+++ b/frontend/components/__tests__/Header.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('../../hooks/useWindowWidth', () => () => 400);
+jest.mock('../Groups', () => () => <div data-testid="groups" />);
+jest.mock('../Account', () => () => <div data-testid="account" />);
+
+import Header from '../Header';
+
+describe('Header', () => {
+  it('calls theme toggle when logo is clicked', async () => {
+    const onToggle = jest.fn();
+    const user = userEvent.setup();
+    render(<Header onThemeToggle={onToggle} currentThemeName="theme-light" />);
+
+    await user.click(screen.getByText(/BAPTENDER/i));
+    expect(onToggle).toHaveBeenCalled();
+  });
+});

--- a/frontend/components/__tests__/LoginForm.test.tsx
+++ b/frontend/components/__tests__/LoginForm.test.tsx
@@ -6,13 +6,14 @@ const noop = () => {};
 
 describe('LoginForm', () => {
   it('allows typing into email and password fields', async () => {
+    const user = userEvent.setup();
     render(<LoginForm onLogin={noop} />);
 
     const emailInput = screen.getByLabelText(/Email/i);
     const passwordInput = screen.getByLabelText(/Password/i);
 
-    await userEvent.type(emailInput, 'test@example.com');
-    await userEvent.type(passwordInput, 'secret');
+    await user.type(emailInput, 'test@example.com');
+    await user.type(passwordInput, 'secret');
 
     expect(emailInput).toHaveValue('test@example.com');
     expect(passwordInput).toHaveValue('secret');


### PR DESCRIPTION
## Summary
- include `aiosqlite` in workflow so backend tests install all deps
- add extra calculation tests covering `get_total_body_water` and `get_widmark_factor`

## Testing
- `pytest -q`
- `npm test -- --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_6843f10758a4833197f11ec8a7e6d1d2