### PR TITLE
Add .env support for auth secret and DB credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ backend/venv
 
 # pycharm
 .idea
+/.env

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ POSTGRES_PASSWORD=<db-password>
 POSTGRES_DB=<db-name>
 ```
 
+The `docker-compose.yml` file uses these values to build a
+`DATABASE_URL` that is passed to the backend service.
+
 Then build the images and start the services with:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -36,8 +36,17 @@ BAPTender is a web application that combines a Next.js frontend with a FastAPI b
 
 ## Docker
 
-You can also run the project using Docker. Build the images and start the
-services with:
+You can also run the project using Docker. Create a `.env` file in the project
+root with the following variables:
+
+```
+SECRET=<your-secret>
+POSTGRES_USER=<db-user>
+POSTGRES_PASSWORD=<db-password>
+POSTGRES_DB=<db-name>
+```
+
+Then build the images and start the services with:
 
 ```bash
 docker compose up --build

--- a/backend/api/auth/auth.py
+++ b/backend/api/auth/auth.py
@@ -4,9 +4,8 @@ from fastapi_users.authentication import (
     BearerTransport,
     JWTStrategy,
 )
+from api.config import SECRET
 
-# TODO: Migrate to environment variables
-SECRET = "SECRET"
 ALGORITHM = "HS256"
 
 bearer_transport = BearerTransport(tokenUrl="auth/jwt/login")

--- a/backend/api/config.py
+++ b/backend/api/config.py
@@ -1,0 +1,20 @@
+import os
+from dotenv import load_dotenv
+
+# Load environment variables from a .env file if present
+load_dotenv()
+
+# Secret used for JWT tokens
+SECRET = os.getenv("SECRET", "dev-secret")
+
+# Database credentials
+POSTGRES_USER = os.getenv("POSTGRES_USER", "postgres")
+POSTGRES_PASSWORD = os.getenv("POSTGRES_PASSWORD", "password")
+POSTGRES_DB = os.getenv("POSTGRES_DB", "baptender")
+DB_HOST = os.getenv("DB_HOST", "localhost")
+DB_PORT = os.getenv("DB_PORT", "5432")
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    f"postgresql+asyncpg://{POSTGRES_USER}:{POSTGRES_PASSWORD}@{DB_HOST}:{DB_PORT}/{POSTGRES_DB}"
+)

--- a/backend/api/core/db.py
+++ b/backend/api/core/db.py
@@ -6,8 +6,8 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from sqlalchemy.orm import DeclarativeBase
 import redis.asyncio as redis
 
-# Use env var for prod config, fallback to local dev
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql+asyncpg://postgres:password@localhost/baptender")
+from api.config import DATABASE_URL
+
 HOST_URL = os.getenv("HOST_URL", "http://localhost:8000")
 REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379")
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,4 @@ apscheduler
 pyjwt
 redis
 sse-starlette
+python-dotenv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,20 +2,20 @@ version: '3.8'
 services:
   db:
     image: postgres:15
+    env_file:
+      - .env
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password
-      POSTGRES_DB: baptender
+      POSTGRES_DB: ${POSTGRES_DB}
     volumes:
       - db_data:/var/lib/postgresql/data
 
   backend:
     build: ./backend
+    env_file:
+      - .env
     environment:
-      DATABASE_URL: postgresql+asyncpg://postgres:password@db/baptender
       DB_HOST: db
       DB_PORT: 5432
-      POSTGRES_USER: postgres
     depends_on:
       - db
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     env_file:
       - .env
     environment:
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB}
       DB_HOST: db
       DB_PORT: 5432
     depends_on:


### PR DESCRIPTION
## Summary
- load environment variables from `.env`
- read SECRET from config in authentication
- build DATABASE_URL from DB credentials
- use `.env` in docker-compose
- document required variables

## Testing
- `pip install -r backend/requirements.txt`
- `pip install pytest pytest-asyncio httpx asgi-lifespan aiosqlite`
- `pytest -q`
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844098c282c8331a011d23f6609be9d