### PR TITLE
Fix graph realtime anchor updates

### DIFF
--- a/frontend/components/Graph.tsx
+++ b/frontend/components/Graph.tsx
@@ -172,10 +172,12 @@ export default function Graph({ currentThemeName }: GraphProps) {
         continue;
       }
 
-      const historical = filtered.map((p: any) => ({
-        x: new Date(p.time).getTime(),
-        y: parseFloat(p.bac) || 0,
-      }));
+      const historical = filtered
+        .map((p: any) => ({
+          x: new Date(p.time).getTime(),
+          y: parseFloat(p.bac) || 0,
+        }))
+        .sort((a, b) => a.x - b.x);
 
       const lastHistPointForCalc =
         historical.length > 0

--- a/frontend/components/Graph.tsx
+++ b/frontend/components/Graph.tsx
@@ -191,8 +191,8 @@ export default function Graph({ currentThemeName }: GraphProps) {
       );
 
       const currentDataPoints = historical.length > 0 ? [...historical] : [];
-      currentDataPoints.push({ x: now, y: realTimeBAC });
       currentDataPoints.sort((a, b) => a.x - b.x);
+      currentDataPoints.push({ x: now, y: realTimeBAC });
 
       const member = state.members.find((m: any) => m.id === uid);
       const label = member?.displayName || uid;


### PR DESCRIPTION
## Summary
- ensure realtime data point is pushed after sorting

## Testing
- `pytest`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684aa249006883318038052c423db21b