### PR TITLE
Add BAC preview when logging drinks

### DIFF
--- a/frontend/components/Drinks.tsx
+++ b/frontend/components/Drinks.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import { useBAPTender } from "@/context/BAPTenderContext";
+import { calculateDrinkBAC, estimateCurrentBAC } from "@/utils/bac";
 
 export default function DrinksForm() {
   const [volume, setVolume] = useState("");
@@ -8,6 +10,33 @@ export default function DrinksForm() {
   const [nickname, setNickname] = useState("");
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [bacAdd, setBacAdd] = useState<number | null>(null);
+  const [bacTotal, setBacTotal] = useState<number | null>(null);
+
+  const { state } = useBAPTender();
+
+  useEffect(() => {
+    const vol = Number(volume);
+    const str = Number(strength);
+    if (isNaN(vol) || vol <= 0 || isNaN(str) || str <= 0) {
+      setBacAdd(null);
+      setBacTotal(null);
+      return;
+    }
+    const user = state.self;
+    if (!user || user.weight <= 0) {
+      setBacAdd(null);
+      setBacTotal(null);
+      return;
+    }
+    const age = user.dob
+      ? (Date.now() - new Date(user.dob).getTime()) / (365.25 * 24 * 60 * 60 * 1000)
+      : undefined;
+    const add = calculateDrinkBAC(vol, str / 100, user.weight, user.gender, age, user.height);
+    const current = estimateCurrentBAC(state.states[user.id]);
+    setBacAdd(add);
+    setBacTotal(current + add);
+  }, [volume, strength, state]);
 
   const handleRemoveLastDrink = async () => {
     setMessage(null);
@@ -190,6 +219,14 @@ export default function DrinksForm() {
           placeholder="Your liver's nemesis"
         />
       </div>
+      {bacAdd !== null && (
+        <p
+          className="text-sm font-sharetech"
+          style={{ color: "var(--accent-color)" }}
+        >
+          BAC impact: +{bacAdd.toFixed(3)}% (new BAC {(bacTotal ?? 0).toFixed(3)}%)
+        </p>
+      )}
       <button type="submit" className="themed-button w-full font-vt323 text-lg">
         Log Drink
       </button>

--- a/frontend/utils/bac.ts
+++ b/frontend/utils/bac.ts
@@ -1,0 +1,42 @@
+export const ALCOHOL_DENSITY = 0.789; // g/mL
+
+function getTotalBodyWater(gender: string, age: number, height: number, weight: number): number {
+  if (gender.toUpperCase() === "MALE") {
+    return 2.447 - 0.09516 * age + 0.1074 * height + 0.3362 * weight;
+  }
+  return -2.097 + 0.1069 * height + 0.2466 * weight;
+}
+
+function getWidmarkFactor(gender: string): number {
+  return gender.toUpperCase() === "MALE" ? 0.68 : 0.55;
+}
+
+export function calculateDrinkBAC(
+  volumeMl: number,
+  strengthDecimal: number,
+  weightKg: number,
+  gender: string,
+  age?: number,
+  heightCm?: number,
+): number {
+  if (!volumeMl || !strengthDecimal || !weightKg || !gender) return 0;
+  const alcoholGrams = volumeMl * strengthDecimal * ALCOHOL_DENSITY;
+
+  if (age !== undefined && heightCm !== undefined) {
+    const tbw = getTotalBodyWater(gender, age, heightCm, weightKg);
+    return Math.max(0, alcoholGrams / (tbw * 10));
+  }
+
+  const bodyWeightG = weightKg * 1000;
+  const widmark = getWidmarkFactor(gender);
+  return Math.max(0, (alcoholGrams / (bodyWeightG * widmark)) * 100);
+}
+
+export function estimateCurrentBAC(states: { time: number | string; bac: number }[] | undefined): number {
+  if (!states || states.length === 0) return 0;
+  const last = states[states.length - 1];
+  const lastTime = typeof last.time === "number" ? last.time : new Date(last.time).getTime();
+  const now = Date.now();
+  const hours = Math.max(0, (now - lastTime) / 3600000);
+  return Math.max(0, last.bac - 0.015 * hours);
+}


### PR DESCRIPTION
## Summary
- show predicted BAC impact in the drink form
- compute BAC increase using same equation as backend
- expose BAC utilities in new helper

## Testing
- `npm test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aa380c66c83319268e7904e97b1bd