### PR TITLE
Add persistent theme storage

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,7 @@
 // app/layout.tsx
 import "./globals.css";
 import React from "react";
+import { cookies } from 'next/headers';
 import Script from 'next/script';
 
 export const metadata = {
@@ -9,8 +10,10 @@ export const metadata = {
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const cookieStore = cookies();
+  const theme = cookieStore.get('theme')?.value || 'theme-og';
   return (
-    <html lang="en" className="theme-og"> {/* Default theme */}
+    <html lang="en" className={theme}>
       <head>
         <Script
           src="https://code.jquery.com/jquery-3.6.0.min.js"

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -21,6 +21,15 @@ export default function HomePage() {
   const router = useRouter();
 
   useEffect(() => {
+    const cookieMatch = document.cookie.match(/(?:^|; )theme=([^;]+)/);
+    const storedTheme = cookieMatch ? cookieMatch[1] : localStorage.getItem("theme");
+    if (storedTheme && themes.includes(storedTheme)) {
+      setCurrentThemeIndex(themes.indexOf(storedTheme));
+      document.documentElement.className = storedTheme;
+    } else {
+      document.documentElement.className = themes[currentThemeIndex];
+    }
+
     const verifyTokenAndInitialize = async () => {
       const storedToken = localStorage.getItem("token");
       // console.log("Stored token on load:", storedToken);
@@ -64,27 +73,30 @@ export default function HomePage() {
     };
 
     verifyTokenAndInitialize();
-
-    // Apply initial theme to HTML element (can remain, or be tied to token state if preferred)
-    document.documentElement.className = themes[currentThemeIndex];
   }, []); // Run once on mount
 
   const toggleTheme = () => {
     const nextThemeIndex = (currentThemeIndex + 1) % themes.length;
     setCurrentThemeIndex(nextThemeIndex);
-    document.documentElement.className = themes[nextThemeIndex];
+    const newTheme = themes[nextThemeIndex];
+    document.documentElement.className = newTheme;
+    localStorage.setItem("theme", newTheme);
+    document.cookie = `theme=${newTheme}; path=/; max-age=31536000`;
   };
 
   // Effect to update document class when theme changes
   useEffect(() => {
-    document.documentElement.className = themes[currentThemeIndex];
+    const themeName = themes[currentThemeIndex];
+    document.documentElement.className = themeName;
+    localStorage.setItem("theme", themeName);
+    document.cookie = `theme=${themeName}; path=/; max-age=31536000`;
   }, [currentThemeIndex]);
 
 
   if (loading) {
     return (
       // Apply the default/current theme even to the loading screen for consistency
-      <div className={`${themes[currentThemeIndex]} flex items-center justify-center min-h-screen bg-bg-color text-text-color`}>
+      <div className="flex items-center justify-center min-h-screen bg-bg-color text-text-color">
         {/* Particle background can also be here if desired during loading */}
         <CustomParticlesBackground currentTheme={themes[currentThemeIndex]} />
         <p className="text-2xl font-sharetech animate-pulse relative z-10">Verifying Session...</p>
@@ -97,7 +109,7 @@ export default function HomePage() {
   if (!token) { // If token is null after loading and verification attempt
     return (
       <PopupProvider>
-        <div className={currentThemeName}>
+        <div>
           <CustomParticlesBackground currentTheme={currentThemeName} />
           <main className="min-h-screen flex flex-col items-center justify-center p-4 relative z-10">
           <h1
@@ -130,7 +142,7 @@ export default function HomePage() {
 return (
   <PopupProvider>
     <BAPTenderProvider token={token}>
-      <div className={currentThemeName}>
+      <div>
         <CustomParticlesBackground currentTheme={currentThemeName} />
         <div className="min-h-screen flex flex-col relative z-10">
           <Header onThemeToggle={toggleTheme} currentThemeName={currentThemeName}/>


### PR DESCRIPTION
## Summary
- persist theme choice via `theme` cookie and localStorage
- load saved theme immediately using cookie in server layout
- sync theme cookie/localStorage on theme change

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ae7b7242483318c25b674e7e90dae