### PR TITLE
Add return button on invite error

### DIFF
--- a/frontend/app/invite/[token]/page.tsx
+++ b/frontend/app/invite/[token]/page.tsx
@@ -36,11 +36,15 @@ export default function InvitePage({ params }: { params: { token: string } }) {
           localStorage.removeItem("pendingInvite");
           setTimeout(() => router.push("/"), 1500);
         } else {
-          const err = await res.json().catch(() => ({ detail: "Unknown error" }));
+          const err = await res
+            .json()
+            .catch(() => ({ detail: "Unknown error" }));
           setStatus(`Failed to join: ${err.detail}`);
+          localStorage.removeItem("pendingInvite");
         }
       } catch (e) {
         setStatus("Network error while joining group.");
+        localStorage.removeItem("pendingInvite");
       }
     };
     join();

--- a/frontend/app/invite/[token]/page.tsx
+++ b/frontend/app/invite/[token]/page.tsx
@@ -63,9 +63,22 @@ export default function InvitePage({ params }: { params: { token: string } }) {
     );
   }
 
+  const showReturn =
+    status.startsWith("Failed") || status.toLowerCase().includes("error");
+
   return (
     <div className="min-h-screen flex items-center justify-center p-4 font-sharetech">
-      <p>{status}</p>
+      <div className="text-center space-y-4">
+        <p>{status}</p>
+        {showReturn && (
+          <button
+            onClick={() => router.push("/")}
+            className="themed-button font-vt323 text-lg"
+          >
+            Return to BAPTender
+          </button>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show a "Return to BAPTender" button when joining a group invite fails

## Testing
- `npm test --prefix frontend -- --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_684aea40fc088331bdb288bf94bd3c19